### PR TITLE
fix & document usage of setXTimeFormat()

### DIFF
--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -169,7 +169,6 @@ class GnuPlot
             $this->sendCommand('set xdata time');
             $this->sendCommand('set timefmt "'.$this->timeFormat.'"');
             $this->sendCommand('set format x "'.$this->timeFormat.'"');
-            $this->sendCommand('set xtics rotate by 45 offset -6,-3');
         }
 
         if ($this->ylabel) {
@@ -270,7 +269,7 @@ class GnuPlot
     }
 
     /**
-     * Sets the X timeformat
+     * Sets the X timeformat, example "%Y-%m-%d"
      */
     public function setXTimeFormat($timeFormat)
     {

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ header('Content-type: image/png');
 echo $plot->get();
 ```
 
-Or display it on the screen (useful with CLI scripts), run the 
+Or display it on the screen (useful with CLI scripts), run the
 `demo.php` script for example:
 
 ```php
@@ -97,10 +97,11 @@ API
 * `writePng($filename)`, write the data to the output file
 * `setTitle($index, $title)`, sets the title of the $index-nt curve
 * `setGraphTitle($title)`, sets the main title for the graph
+* `setXTimeFormat($fmtString)` sets the X axis as a time axis and specify format
 * `setXLabel($text)`, sets the label for the X axis
 * `setYLabel($text)`, sets the label for the Y axis
-* `setXRange($min, $max)`, set the X min & max 
-* `setYRange($min, $max)`, set the Y min & max 
+* `setXRange($min, $max)`, set the X min & max
+* `setYRange($min, $max)`, set the Y min & max
 * `setWidth($width)`, sets the width of the graph
 * `setHeight($height)`, sets the width of the graph
 * `addLabel($x, $y, $text)`, add some label at a point
@@ -109,4 +110,3 @@ License
 =======
 
 `Gregwar\GnuPlot` is under MIT license
-


### PR DESCRIPTION
I was about to try to add time format on the x line support when i found it was already in there. However there was a repositioning of the label that makes it outside of the generated image, which I removed.