### PR TITLE
Added PDF and EPS output support

### DIFF
--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -1,9 +1,16 @@
-<?php
+<?php namespace Gregwar\GnuPlot;
 
-namespace Gregwar\GnuPlot;
-
-class GnuPlot
-{
+class GnuPlot {
+	// Available units
+	const UNIT_BLANK	= '';
+	const UNIT_INCH 	= 'in';
+	const UNIT_CM		= 'cm';
+	
+	// Available terminals
+	const TERMINAL_PNG	= 'png';
+	const TERMINAL_PDF	= 'pdf';
+	const TERMINAL_EPS	= 'eps';
+	
     // Values as an array
     protected $values = array();
 
@@ -21,6 +28,9 @@ class GnuPlot
 
     // Plot height
     protected $height = 800;
+	
+	// Size unit.
+	protected $unit = self::UNIT_BLANK;
 
     // Was it already plotted?
     protected $plotted = false;
@@ -144,6 +154,16 @@ class GnuPlot
 
         return $this;
     }
+	
+	/**
+     * Sets the graph size unit. You can use one of the UNIT_ constants defined in this class.
+     */
+	public function setUnit($unit)
+	{
+		$this->unit = $unit;
+
+		return $this;
+	}
 
     /**
      * Sets the graph title
@@ -213,25 +233,49 @@ class GnuPlot
         $this->plotted = true;
         $this->sendData();
     }
+	
+	/**
+     * Write the current plot to a file
+     */
+	public function write($terminal, $file)
+	{
+		$this->sendInit();
+		$this->sendCommand("set terminal $terminal size {$this->width}{$this->unit}, {$this->height}{$this->unit}");
+		$this->sendCommand('set output "'.$file.'"');
+		$this->plot();
+	}
 
     /**
-     * Write the current plot to a file
+     * Write the current plot to a PNG file
      */
     public function writePng($file)
     {
-        $this->sendInit();
-        $this->sendCommand('set terminal png size '.$this->width.','.$this->height);
-        $this->sendCommand('set output "'.$file.'"');
-        $this->plot();
+        $this->write(self::TERMINAL_PNG, $file);
     }
+	
+	/**
+     * Write the current plot to a PDF file
+     */
+	public function writePDF($file)
+	{
+		$this->write(self::TERMINAL_PDF, $file);
+	}
+	
+	/**
+     * Write the current plot to an EPS file
+     */
+	public function writeEPS($file)
+	{
+		$this->write(self::TERMINAL_EPS, $file);
+	}
 
     /**
      * Write the current plot to a file
      */
-    public function get()
+    public function get($format = self::TERMINAL_PNG)
     {
         $this->sendInit();
-        $this->sendCommand('set terminal png size '.$this->width.','.$this->height);
+		$this->sendCommand("set terminal $format size {$this->width}{$this->unit}, {$this->width}{$this->unit}");
         fflush($this->stdout);
         $this->plot();
 

--- a/demo/eps.php
+++ b/demo/eps.php
@@ -1,0 +1,38 @@
+<?php
+
+include ('../GnuPlot.php');
+
+use Gregwar\GnuPlot\GnuPlot;
+
+$plot = new GnuPlot;
+
+$plot
+	// Setting graph main title
+	->setGraphTitle('Demo graph')
+	// Setting X & Y labels
+	->setXLabel('Something')
+	->setYLabel('Another something')
+	// Set the unit to inches
+	->setUnit(GnuPlot::UNIT_INCH)
+	// Setting graph dimensions to those of an A4 sheet
+	->setWidth(11.02)
+	->setHeight(8.27)
+	// Demo curve (index=0)
+	->setTitle(0, 'Demo')
+	->push(0, 1)
+	->push(1, 10)
+	->push(2, 3)
+	->push(3, 2.6)
+	->push(4, 5.3)
+	// Other curve, (index=1)
+	->setTitle(1, 'Other curve')
+	->push(0, 3.9, 1)
+	->push(1, 2.3, 1)
+	->push(2, 4.3, 1)
+	->push(3, 3.1, 1)
+	->push(4, 5.2, 1)
+	// Pointing out a value
+	->addLabel(2, 4.3, 'An important point')
+	// Writing to out.png
+	->writeEPS('out.eps');
+

--- a/demo/pdf.php
+++ b/demo/pdf.php
@@ -1,0 +1,38 @@
+<?php
+
+include ('../GnuPlot.php');
+
+use Gregwar\GnuPlot\GnuPlot;
+
+$plot = new GnuPlot;
+
+$plot
+	// Setting graph main title
+	->setGraphTitle('Demo graph')
+	// Setting X & Y labels
+	->setXLabel('Something')
+	->setYLabel('Another something')
+	// Set the unit to inches
+	->setUnit(GnuPlot::UNIT_INCH)
+	// Setting graph dimensions to those of an A4 sheet
+	->setWidth(11.02)
+	->setHeight(8.27)
+	// Demo curve (index=0)
+	->setTitle(0, 'Demo')
+	->push(0, 1)
+	->push(1, 10)
+	->push(2, 3)
+	->push(3, 2.6)
+	->push(4, 5.3)
+	// Other curve, (index=1)
+	->setTitle(1, 'Other curve')
+	->push(0, 3.9, 1)
+	->push(1, 2.3, 1)
+	->push(2, 4.3, 1)
+	->push(3, 3.1, 1)
+	->push(4, 5.2, 1)
+	// Pointing out a value
+	->addLabel(2, 4.3, 'An important point')
+	// Writing to out.png
+	->writePDF('out.pdf');
+


### PR DESCRIPTION
I added a couple of functions to allow output to PDF and EPS files. Both require the relevant terminal to be available within gnuplot (for PDF it's `pdfcairo` while for EPS is `epscairo`). I also added the ability to set the size unit, which defaults to blank in order to preserve backwards compatibility, and can be set to both `cm` or `in` (or anything else, really, but I don't know what else is supported :) ).