### PR TITLE
Added line width, line point and line smoothing support. Fixed some bugs.

### DIFF
--- a/.php_cs.dist
+++ b/.php_cs.dist
@@ -1,0 +1,98 @@
+<?php
+/*
+ * This document has been generated with
+ * https://mlocati.github.io/php-cs-fixer-configurator/?version=2.15#configurator
+ * you can change this configuration by importing this file.
+ */
+return PhpCsFixer\Config::create()->setRiskyAllowed(true)->setRules([
+        '@PSR1'                                 => true,
+        '@PSR2'                                 => true,
+        // Each line of multi-line DocComments must have an asterisk [PSR-5] and must be aligned with the first one.
+        'align_multiline_comment'               => ['comment_type' => 'phpdocs_like'],
+        // PHP arrays should be declared using the configured syntax.
+        'array_syntax'                          => ['syntax' => 'short'],
+        // Binary operators should be surrounded by space as configured.
+        'binary_operator_spaces'                => [
+            'align_double_arrow' => true,
+            'align_equals'       => false
+        ],
+        // An empty line feed should precede a return statement.
+        'blank_line_before_return'              => true,
+        // Concatenation should be spaced according configuration.
+        'concat_space'                          => false,
+        // Equal sign in declare statement should be surrounded by spaces or not following configuration.
+        'declare_equal_normalize'               => false,
+        // Force strict types declaration in all files.
+        // Requires PHP >= 7.0.
+        'declare_strict_types'                  => true,
+        // Transforms imported FQCN parameters and return types in function arguments to short version.
+        'fully_qualified_strict_types'          => true,
+        // All instances created with new keyword must be followed by braces.
+        'new_with_braces'                       => true,
+        // There should not be blank lines between docblock and the documented element.
+        'no_blank_lines_after_phpdoc'           => true,
+        // There should not be any empty comments.
+        'no_empty_comment'                      => true,
+        // There should not be empty PHPDoc blocks.
+        'no_empty_phpdoc'                       => true,
+        // Remove useless semicolon statements.
+        'no_empty_statement'                    => true,
+        // Remove trailing commas in list function calls.
+        'no_trailing_comma_in_list_call'        => true,
+        // PHP single-line arrays should not have trailing comma.
+        'no_trailing_comma_in_singleline_array' => true,
+        // Removes unneeded curly braces that are superfluous and aren't part of a control structure's body.
+        'no_unneeded_curly_braces'              => true,
+        // There should not be useless `else` cases.
+        'no_useless_else'                       => true,
+        // There should not be an empty `return` statement at the end of a function.
+        'no_useless_return'                     => true,
+        // Array index should always be written by using square braces.
+        'normalize_index_brace'                 => true,
+        // PHPDoc should contain `@param` for all params.
+        'phpdoc_add_missing_param_annotation'   => true,
+        // All items of the given phpdoc tags must be either left-aligned or (by default) aligned vertically.
+        'phpdoc_align'                          => true,
+        // PHPDoc annotation descriptions should not be a sentence.
+        'phpdoc_annotation_without_dot'         => true,
+        // Docblocks should have the same indentation as the documented subject.
+        'phpdoc_indent'                         => true,
+        // Fix PHPDoc inline tags, make `@inheritdoc` always inline.
+        'phpdoc_inline_tag'                     => true,
+        // `@access` annotations should be omitted from PHPDoc.
+        'phpdoc_no_access'                      => true,
+        // `@return void` and `@return null` annotations should be omitted from PHPDoc.
+        'phpdoc_no_empty_return'                => true,
+        // `@package` and `@subpackage` annotations should be omitted from PHPDoc.
+        'phpdoc_no_package'                     => true,
+        // Classy that does not inherit must not have `@inheritdoc` tags.
+        'phpdoc_no_useless_inheritdoc'          => true,
+        // Annotations in PHPDoc should be ordered so that `@param` annotations come first, then `@throws` annotations, then `@return` annotations.
+        'phpdoc_order'                          => true,
+        // Scalar types should always be written in the same form.
+        // `int` not `integer`, `bool` not `boolean`, `float` not `real` or `double`.
+        'phpdoc_scalar'                         => true,
+        // Single line `@var` PHPDoc should have proper spacing.
+        'phpdoc_single_line_var_spacing'        => true,
+        // PHPDoc summary should end in either a full stop, exclamation mark, or question mark.
+        'phpdoc_summary'                        => true,
+        // Docblocks should only be used on structural elements.
+        'phpdoc_to_comment'                     => true,
+        // PHPDoc should start and end with content, excluding the very first and last line of the docblocks.
+        'phpdoc_trim'                           => true,
+        // The correct case must be used for standard PHP types in PHPDoc.
+        'phpdoc_types'                          => true,
+        // There should be one or no space before colon, and one space after it in return type declarations, according to configuration.
+        'return_type_declaration'               => true,
+        // Replace all `<>` with `!=`.
+        'standardize_not_equals'                => true,
+        // Comparisons should be strict.
+        'strict_comparison'                     => true,
+        // PHP multi-line arrays should have a trailing comma.
+        'trailing_comma_in_multiline_array'     => true,
+        // Add void return type to functions with missing or empty return statements, but priority is given to `@return` annotations.
+        // Requires PHP >= 7.1.
+        'void_return'                           => true,
+        // Write conditions in Yoda style (`true`), non-Yoda style (`false`) or ignore those conditions (`null`) based on configuration.
+        'yoda_style'                            => true,
+    ])->setFinder(PhpCsFixer\Finder::create()->exclude('vendor')->in(__DIR__));

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -49,6 +49,9 @@ class GnuPlot {
     
     // Line Widths
     protected $lineWidth;
+
+    // Line Modes
+    protected $lineModes;
     
     // Line Points
     protected $linePoints;

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -537,7 +537,7 @@ class GnuPlot {
         $width = $this->canvasWidth ?: $this->width;
 
         $this->sendInit();
-        $this->sendCommand("set terminal $format size {$width}{$this->unit}, {$width}{$this->unit}");
+        $this->sendCommand("set terminal $format size {$width}{$this->unit}, {$height}{$this->unit}");
 
         if ($this->canvasWidth && $this->canvasHeight) {
             $this->sendCommand("set size {$this->width} {$this->height}");

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -14,6 +14,8 @@ class GnuPlot {
     const SMOOTH_NONE   = null;
     const SMOOTH_SPLINE = 'cspline';
     const SMOOTH_BEZIER = 'bezier';
+
+    const PROPERTY_LINES = 'lines';
     
     // Values as an array
     protected $values = array();
@@ -75,6 +77,12 @@ class GnuPlot {
     // Y range scale
     protected $yrange;
 
+    // X tics
+    protected $xtics;
+
+    // Y tics
+    protected $ytics;
+
     protected $yformat = null;
 
     // Graph title
@@ -108,6 +116,12 @@ class GnuPlot {
         $this->initialize();
     }
 
+    public function __get($property) {
+        if ($property === self::PROPERTY_LINES) {
+            return count($this->values);
+        }
+    }
+
     /**
      * Reset all the values
      */
@@ -125,6 +139,8 @@ class GnuPlot {
         $this->lineSmooths = array();
         $this->xrange = null;
         $this->yrange = null;
+        $this->xtics = null;
+        $this->ytics = null;
         $this->title = null;
     }
 
@@ -144,6 +160,26 @@ class GnuPlot {
     public function setYRange($min, $max)
     {
         $this->yrange = array($min, $max);
+
+        return $this;
+    }
+
+    /**
+     * Sets the X tics for values
+     */
+    public function setXTics($tics)
+    {
+        $this->xtics = $tics;
+
+        return $this;
+    }
+
+    /**
+     * Sets the Y tics for values
+     */
+    public function setYTics($tics)
+    {
+        $this->ytics = $tics;
 
         return $this;
     }
@@ -308,6 +344,14 @@ class GnuPlot {
 
         if ($this->yrange) {
             $this->sendCommand('set yrange ['.$this->yrange[0].':'.$this->yrange[1].']');
+        }
+
+        if ($this->xtics) {
+            $this->sendCommand('set xtics ' . $this->xtics);
+        }
+
+        if ($this->ytics) {
+            $this->sendCommand('set ytics ' . $this->ytics);
         }
 
         foreach ($this->labels as $label) {

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -232,7 +232,6 @@ class GnuPlot
     {
         $command .= PHP_EOL;
         fwrite($this->stdin, $command);
-        echo $command;
     }
 
     public function flush(): void

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -15,6 +15,8 @@ class GnuPlot {
     const SMOOTH_SPLINE = 'cspline';
     const SMOOTH_BEZIER = 'bezier';
 
+    const LINEMODE_FILLEDCURVES = 'filledcurves';
+
     const PROPERTY_LINES = 'lines';
     
     // Values as an array
@@ -583,7 +585,12 @@ class GnuPlot {
         $usings = array();
 
         for ($i=0; $i<count($this->values); $i++) {
-            $using = '"-" using 1:2 with '. (isset($this->lineModes[$i]) ? $this->lineModes[$i] : $this->mode);
+            if (isset($this->lineModes[$i]) && $this->lineModes[$i] === self::LINEMODE_FILLEDCURVES) {
+                $using = '"-" using 1:2:3 with filledcurves ';
+            } else {
+                $using = '"-" using 1:2 with ' . (isset($this->lineModes[$i]) ? $this->lineModes[$i] : $this->mode);
+            }
+
             if (isset($this->titles[$i])) {
                 $using .= ' title "'.$this->titles[$i].'"';
             }
@@ -619,7 +626,11 @@ class GnuPlot {
         foreach ($this->values as $index => $data) {
             foreach ($data as $xy) {
                 list($x, $y) = $xy;
-                $this->sendCommand($x.' '.$y);
+                if (is_array($y)) {
+                    $this->sendCommand($x.' '.current($y).' '.next($y));
+                } else {
+                    $this->sendCommand($x.' '.$y);
+                }
             }
             $this->sendCommand('e');
         }
@@ -628,7 +639,7 @@ class GnuPlot {
     /**
      * Sends a command to the gnuplot process
      */
-    protected function sendCommand($command)
+    public function sendCommand($command)
     {
         $command .= "\n";
         fwrite($this->stdin, $command);

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -744,3 +744,4 @@ class GnuPlot {
         $this->stdout = $pipes[1];
     }
 }
+

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -8,12 +8,16 @@ class GnuPlot {
     
     // Available terminals
     const TERMINAL_PNG  = 'png';
-    const TERMINAL_PDF  = 'pdf';
+    const TERMINAL_PDF  = 'pdf dashed';
     const TERMINAL_EPS  = 'eps';
 
     const SMOOTH_NONE   = null;
     const SMOOTH_SPLINE = 'cspline';
     const SMOOTH_BEZIER = 'bezier';
+
+    const GRID_FRONT    = 'front';
+    const GRID_BACK     = 'back';
+    const GRID_DEFAULT  = 'layerdefault';
 
     const LINEMODE_FILLEDCURVES = 'filledcurves';
 
@@ -55,6 +59,9 @@ class GnuPlot {
     // Should draw grid for minor ticks
     protected $minorGrid = false;
 
+    // Grid placement (front, back, layerdefault)
+    protected $gridPlacement;
+
     // X Label
     protected $xlabel;
 
@@ -78,6 +85,9 @@ class GnuPlot {
 
     // Line Types
     protected $lineTypes;
+
+    // Line Colors
+    protected $lineColors;
 
     // Smooth Mode
     protected $lineSmooths;
@@ -159,6 +169,7 @@ class GnuPlot {
         $this->linePoints = array();
         $this->lineModes = array();
         $this->lineTypes = array();
+        $this->lineColors = array();
         $this->lineSmooths = array();
         $this->origin = array(0,0);
         $this->xrange = null;
@@ -168,6 +179,7 @@ class GnuPlot {
         $this->mxtics = null;
         $this->mytics = null;
         $this->minorGrid = false;
+        $this->gridPlacement = self::GRID_DEFAULT;
         $this->title = null;
         $this->key = null;
     }
@@ -253,6 +265,16 @@ class GnuPlot {
     }
 
     /**
+     * Specifies the layer for the grid
+     */
+    public function setGridPlacement($layer)
+    {
+        $this->gridPlacement = $layer;
+
+        return $this;
+    }
+
+    /**
      * Push a new data, $x is a number, $y can be a number or an array
      * of numbers
      */
@@ -311,6 +333,15 @@ class GnuPlot {
      */
     public function setLineType($index, $type) {
         $this->lineTypes[$index] = $type;
+        
+        return $this;
+    }
+
+    /**
+     * Sets the line color of the $index th curve in the plot
+     */
+    public function setLineColor($index, $color) {
+        $this->lineColors[$index] = $color;
         
         return $this;
     }
@@ -403,6 +434,8 @@ class GnuPlot {
         if ($this->minorGrid === true) {
             $gridCommand .= ' mxtics mytics';
         }
+        $gridCommand .= ' ' . $this->gridPlacement;
+
         $this->sendCommand($gridCommand);
 
         if ($this->title) {
@@ -675,6 +708,10 @@ class GnuPlot {
 
             if (isset($this->lineTypes[$i])) {
                 $using .= ' lt ' . $this->lineTypes[$i];
+            }
+
+            if (isset($this->lineColors[$i])) {
+                $using .= ' lc ' . $this->lineColors[$i];
             }
 
             if (isset($this->lineWidths[$i])) {

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -94,6 +94,9 @@ class GnuPlot {
     // Y mtics
     protected $mytics;
 
+    // Legend position
+    protected $key;
+
     protected $yformat = null;
 
     // Graph title
@@ -156,6 +159,7 @@ class GnuPlot {
         $this->mytics = null;
         $this->minorGrid = false;
         $this->title = null;
+        $this->key = null;
     }
 
     /**
@@ -365,6 +369,10 @@ class GnuPlot {
             $this->sendCommand('set title "'.$this->title.'"');
         }
 
+        if ($this->key) {
+            $this->sendCommand('set key ' . $this->key);
+        }
+
         if ($this->xlabel) {
             $this->sendCommand('set xlabel "'.$this->xlabel.'"');
         }
@@ -556,6 +564,16 @@ class GnuPlot {
 
         return $this;
     }
+
+    /**
+     * Sets the legend position
+     */
+    public function setKey($x, $y)
+    {
+        $this->key = "$x $y";
+
+        return $this;
+    }    
 
     /**
      * Add a label text

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -1,62 +1,82 @@
-<?php namespace Gregwar\GnuPlot;
+<?php declare(strict_types=1);
 
-class GnuPlot {
+namespace Gregwar\GnuPlot;
+
+use Exception;
+
+class GnuPlot
+{
     // Available units
-    const UNIT_BLANK    = '';
-    const UNIT_INCH     = 'in';
-    const UNIT_CM       = 'cm';
-    
-    // Available terminals
-    const TERMINAL_PNG  = 'png';
-    const TERMINAL_PDF  = 'pdf dashed';
-    const TERMINAL_EPS  = 'eps';
+    const UNIT_BLANK = '';
+    const UNIT_INCH = 'in';
+    const UNIT_CM = 'cm';
 
-    const SMOOTH_NONE   = null;
+    // Available terminals
+    const TERMINAL_PNG = 'png';
+    const TERMINAL_PDF = 'pdf dashed';
+    const TERMINAL_EPS = 'eps';
+
+    const SMOOTH_NONE = null;
     const SMOOTH_SPLINE = 'cspline';
     const SMOOTH_BEZIER = 'bezier';
 
-    const GRID_FRONT    = 'front';
-    const GRID_BACK     = 'back';
-    const GRID_DEFAULT  = 'layerdefault';
+    const GRID_FRONT = 'front';
+    const GRID_BACK = 'back';
+    const GRID_DEFAULT = 'layerdefault';
 
     const LINEMODE_FILLEDCURVES = 'filledcurves';
 
     const PROPERTY_LINES = 'lines';
-    
-    // Values as an array
-    protected $values = array();
 
-    // Time format if X data is time
+    // Values as an array
+    protected $values = [];
+
+    /**
+     * Time format if X data is time.
+     * @var string
+     */
     protected $timeFormat = null;
 
     // Time presentation format for X, if $timeFormat is set
     protected $timeFormatString = null;
 
     // Display mode
-    protected $mode = 'line';
+    protected $mode = 'lines';
 
-    // Plot width
+    /** Plot width
+     * @var int
+     */
     protected $width = 1200;
 
-    // Plot height
+    /** Plot height
+     * @var int
+     */
     protected $height = 800;
 
-    // Canvas height
+    /** Canvas height
+     * @var int
+     */
     protected $canvasHeight;
 
-    // Canvas width
+    /** Canvas width
+     * @var int
+     */
     protected $canvasWidth;
 
-    // Default sleep time
+    /** Default sleep time
+     * @var int
+     */
     protected $sleepTime = 5000;
-    
+
     // Size unit.
     protected $unit = self::UNIT_BLANK;
 
-    // Was it already plotted?
+    /** Was it already plotted?
+     * @var bool
+     */
     protected $plotted = false;
 
-    // Should draw grid for minor ticks
+    /** Should draw grid for minor ticks */
     protected $minorGrid = false;
 
     // Grid placement (front, back, layerdefault)
@@ -73,13 +93,13 @@ class GnuPlot {
 
     // Titles
     protected $titles;
-    
+
     // Line Widths
-    protected $lineWidth;
+    protected $lineWidths;
 
     // Line Modes
     protected $lineModes;
-    
+
     // Line Points
     protected $linePoints;
 
@@ -126,52 +146,37 @@ class GnuPlot {
     protected $stdin;
     protected $stdout;
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->initialize();
-    }
-
-    public function __destruct() {
-       $this->cleanup();
-    }
-    
-    protected function initialize() {
-        $this->reset();
-        $this->openPipe();
-    }
-    
-    protected function cleanup() {
-        $this->sendCommand('quit');
-        proc_close($this->process);
-    }
-
-    public function flush() {
-        $this->cleanup();
-        $this->initialize();
-    }
-
-    public function __get($property) {
-        if ($property === self::PROPERTY_LINES) {
-            return count($this->values);
-        }
     }
 
     /**
-     * Reset all the values
+     * @throws Exception
      */
-    public function reset()
+    protected function initialize(): void
     {
-        $this->values = array();
+        $this->reset();
+        $this->openPipe();
+    }
+
+    /**
+     * Reset all the values.
+     */
+    public function reset(): void
+    {
+        $this->values = [];
         $this->xlabel = null;
         $this->ylabel = null;
-        $this->labels = array();
-        $this->titles = array();
-        $this->lineWidths = array();
-        $this->linePoints = array();
-        $this->lineModes = array();
-        $this->lineTypes = array();
-        $this->lineColors = array();
-        $this->lineSmooths = array();
-        $this->origin = array(0,0);
+        $this->labels = [];
+        $this->titles = [];
+        $this->lineWidths = [];
+        $this->linePoints = [];
+        $this->lineModes = [];
+        $this->lineTypes = [];
+        $this->lineColors = [];
+        $this->lineSmooths = [];
+        $this->origin = [0, 0];
         $this->xrange = null;
         $this->yrange = null;
         $this->xtics = null;
@@ -185,37 +190,107 @@ class GnuPlot {
     }
 
     /**
-     * Sets the X Range for values
+     * Open the pipe.
+     *
+     * @throws Exception
+     */
+    protected function openPipe(): void
+    {
+        $descriptorspec = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'r'],
+        ];
+
+        $this->process = proc_open('gnuplot', $descriptorspec, $pipes);
+
+        if (!is_resource($this->process)) {
+            throw new Exception('Unable to run GnuPlot');
+        }
+
+        $this->stdin = $pipes[0];
+        $this->stdout = $pipes[1];
+    }
+
+    public function __destruct()
+    {
+        $this->cleanup();
+    }
+
+    protected function cleanup(): void
+    {
+        $this->sendCommand('quit');
+        proc_close($this->process);
+    }
+
+    /**
+     * Sends a command to the gnuplot process.
+     *
+     * @param mixed $command
+     */
+    public function sendCommand($command): void
+    {
+        $command .= PHP_EOL;
+        fwrite($this->stdin, $command);
+        echo $command;
+    }
+
+    public function flush(): void
+    {
+        $this->cleanup();
+        $this->initialize();
+    }
+
+    public function __get($property)
+    {
+        if (self::PROPERTY_LINES === $property) {
+            return count($this->values);
+        }
+    }
+
+    /**
+     * Sets the X Range for values.
+     *
+     * @param mixed $min
+     * @param mixed $max
      */
     public function setXRange($min, $max)
     {
-        $this->xrange = array($min, $max);
+        $this->xrange = [$min, $max];
 
         return $this;
     }
 
     /**
-     * Sets the Y Range for values
+     * Sets the Y Range for values.
+     *
+     * @param mixed $min
+     * @param mixed $max
      */
     public function setYRange($min, $max)
     {
-        $this->yrange = array($min, $max);
+        $this->yrange = [$min, $max];
 
         return $this;
     }
 
     /**
-     * Sets the graph origin in the canvas
+     * Sets the graph origin in the canvas.
+     *
+     * @param mixed $min
+     * @param mixed $max
      */
     public function setOrigin($min, $max)
     {
-        $this->origin = array($min, $max);
+        $this->origin = [$min, $max];
 
         return $this;
     }
 
     /**
-     * Sets the X tics for values
+     * Sets the X tics for values.
+     *
+     * @param mixed $tics
      */
     public function setXTics($tics)
     {
@@ -225,9 +300,11 @@ class GnuPlot {
     }
 
     /**
-     * Sets the Y tics for values
+     * Sets the Y tics for values.
+     *
+     * @param mixed $tics
      */
-    public function setYTics($tics)
+    public function setYTics(float $tics): self
     {
         $this->ytics = $tics;
 
@@ -235,9 +312,11 @@ class GnuPlot {
     }
 
     /**
-     * Sets the X mtics for values
+     * Sets the X mtics for values.
+     *
+     * @param mixed $tics
      */
-    public function setMXTics($tics)
+    public function setMXTics(float $tics): self
     {
         $this->mxtics = $tics;
 
@@ -245,9 +324,11 @@ class GnuPlot {
     }
 
     /**
-     * Sets the Y mtics for values
+     * Sets the Y mtics for values.
+     *
+     * @param mixed $tics
      */
-    public function setMYTics($tics)
+    public function setMYTics(float $tics): self
     {
         $this->mytics = $tics;
 
@@ -255,7 +336,9 @@ class GnuPlot {
     }
 
     /**
-     * Enables or disabled the grid for minor tics
+     * Enables or disabled the grid for minor tics.
+     *
+     * @param mixed $status
      */
     public function setMinorGrid($status)
     {
@@ -265,7 +348,9 @@ class GnuPlot {
     }
 
     /**
-     * Specifies the layer for the grid
+     * Specifies the layer for the grid.
+     *
+     * @param mixed $layer
      */
     public function setGridPlacement($layer)
     {
@@ -276,21 +361,28 @@ class GnuPlot {
 
     /**
      * Push a new data, $x is a number, $y can be a number or an array
-     * of numbers
+     * of numbers.
+     *
+     * @param mixed $x
+     * @param mixed $y
+     * @param mixed $index
      */
     public function push($x, $y, $index = 0)
     {
         if (!isset($this->values[$index])) {
-            $this->values[$index] = array();
+            $this->values[$index] = [];
         }
 
-        $this->values[$index][] = array($x, $y);
+        $this->values[$index][] = [$x, $y];
 
         return $this;
     }
 
     /**
-     * Sets the title of the $index th curve in the plot
+     * Sets the title of the $index th curve in the plot.
+     *
+     * @param mixed $index
+     * @param mixed $title
      */
     public function setTitle($index, $title)
     {
@@ -298,9 +390,12 @@ class GnuPlot {
 
         return $this;
     }
-    
+
     /**
-     * Sets the line width of the $index th curve in the plot
+     * Sets the line width of the $index th curve in the plot.
+     *
+     * @param mixed $index
+     * @param mixed $width
      */
     public function setLineWidth($index, $width)
     {
@@ -308,9 +403,12 @@ class GnuPlot {
 
         return $this;
     }
-    
+
     /**
-     * Sets the line point of the $index th curve in the plot
+     * Sets the line point of the $index th curve in the plot.
+     *
+     * @param mixed $index
+     * @param mixed $point
      */
     public function setLinePoint($index, $point)
     {
@@ -318,45 +416,63 @@ class GnuPlot {
 
         return $this;
     }
-    
+
     /**
-     * Sets the line mode of the $index th curve in the plot
+     * Sets the line mode of the $index th curve in the plot.
+     *
+     * @param mixed $index
+     * @param mixed $mode
      */
-    public function setLineMode($index, $mode) {
+    public function setLineMode($index, $mode)
+    {
         $this->lineModes[$index] = $mode;
-        
+
         return $this;
     }
 
     /**
-     * Sets the line type of the $index th curve in the plot
+     * Sets the line type of the $index th curve in the plot.
+     *
+     * @param mixed $index
+     * @param mixed $type
      */
-    public function setLineType($index, $type) {
+    public function setLineType($index, $type)
+    {
         $this->lineTypes[$index] = $type;
-        
+
         return $this;
     }
 
     /**
-     * Sets the line color of the $index th curve in the plot
+     * Sets the line color of the $index th curve in the plot.
+     *
+     * @param mixed $index
+     * @param mixed $color
      */
-    public function setLineColor($index, $color) {
+    public function setLineColor($index, $color)
+    {
         $this->lineColors[$index] = $color;
-        
+
         return $this;
     }
 
     /**
-     * Sets the line smooth of the $index th curve in the plot
+     * Sets the line smooth of the $index th curve in the plot.
+     *
+     * @param mixed $index
+     * @param mixed $smooth
      */
-    public function setLineSmooth($index, $smooth) {
+    public function setLineSmooth($index, $smooth)
+    {
         $this->lineSmooths[$index] = $smooth;
 
         return $this;
     }
 
     /**
-     * Sets the graph width
+     * Sets the graph width.
+     *
+     * @param mixed $width
      */
     public function setWidth($width)
     {
@@ -366,7 +482,9 @@ class GnuPlot {
     }
 
     /**
-     * Sets the graph height
+     * Sets the graph height.
+     *
+     * @param mixed $height
      */
     public function setHeight($height)
     {
@@ -376,7 +494,9 @@ class GnuPlot {
     }
 
     /**
-     * Sets the canvas width
+     * Sets the canvas width.
+     *
+     * @param mixed $width
      */
     public function setCanvasWidth($width)
     {
@@ -386,7 +506,9 @@ class GnuPlot {
     }
 
     /**
-     * Sets the canvas height
+     * Sets the canvas height.
+     *
+     * @param mixed $height
      */
     public function setCanvasHeight($height)
     {
@@ -396,7 +518,9 @@ class GnuPlot {
     }
 
     /**
-     * Sets the sleep time
+     * Sets the sleep time.
+     *
+     * @param mixed $sleepTime
      */
     public function setSleepTime($sleepTime)
     {
@@ -404,9 +528,11 @@ class GnuPlot {
 
         return $this;
     }
-    
+
     /**
      * Sets the graph size unit. You can use one of the UNIT_ constants defined in this class.
+     *
+     * @param mixed $unit
      */
     public function setUnit($unit)
     {
@@ -416,7 +542,9 @@ class GnuPlot {
     }
 
     /**
-     * Sets the graph title
+     * Sets the graph title.
+     *
+     * @param mixed $title
      */
     public function setGraphTitle($title)
     {
@@ -426,12 +554,48 @@ class GnuPlot {
     }
 
     /**
-     * Create the pipe
+     * Write the current plot to a PNG file.
+     *
+     * @param mixed $file
      */
-    protected function sendInit()
+    public function writePng($file): void
+    {
+        $this->write(self::TERMINAL_PNG, $file);
+    }
+
+    /**
+     * Write the current plot to a file.
+     *
+     * @param mixed $terminal
+     * @param mixed $file
+     */
+    public function write($terminal, $file): void
+    {
+        $height = $this->canvasHeight ?: $this->height;
+        $width = $this->canvasWidth ?: $this->width;
+
+        $this->sendInit();
+        $this->sendCommand("set terminal $terminal size {$width}{$this->unit}, {$height}{$this->unit}");
+        $this->sendCommand('set output "' . $file . '"');
+
+        if ($this->canvasWidth && $this->canvasHeight) {
+            $this->sendCommand("set size {$this->width}, {$this->height}");
+        }
+
+        $this->plot();
+
+        // Flush the output as described here: http://www.gnuplot.info/faq/faq.html#x1-840007.6
+        $this->sendCommand('set output');
+        usleep($this->sleepTime);
+    }
+
+    /**
+     * Create the pipe.
+     */
+    protected function sendInit(): void
     {
         $gridCommand = 'set grid xtics ytics';
-        if ($this->minorGrid === true) {
+        if (true === $this->minorGrid) {
             $gridCommand .= ' mxtics mytics';
         }
         $gridCommand .= ' ' . $this->gridPlacement;
@@ -439,7 +603,7 @@ class GnuPlot {
         $this->sendCommand($gridCommand);
 
         if ($this->title) {
-            $this->sendCommand('set title "'.$this->title.'"');
+            $this->sendCommand('set title "' . $this->title . '"');
         }
 
         if ($this->key) {
@@ -447,7 +611,7 @@ class GnuPlot {
         }
 
         if ($this->xlabel) {
-            $this->sendCommand('set xlabel "'.$this->xlabel.'"');
+            $this->sendCommand('set xlabel "' . $this->xlabel . '"');
         }
 
         if ($this->origin) {
@@ -456,27 +620,27 @@ class GnuPlot {
 
         if ($this->timeFormat) {
             $this->sendCommand('set xdata time');
-            $this->sendCommand('set timefmt "'.$this->timeFormat.'"');
+            $this->sendCommand('set timefmt "' . $this->timeFormat . '"');
             $this->sendCommand('set xtics rotate by 45 offset -6,-3');
             if ($this->timeFormatString) {
-                $this->sendCommand('set format x "'.$this->timeFormatString.'"');
+                $this->sendCommand('set format x "' . $this->timeFormatString . '"');
             }
         }
 
         if ($this->ylabel) {
-            $this->sendCommand('set ylabel "'.$this->ylabel.'"');
+            $this->sendCommand('set ylabel "' . $this->ylabel . '"');
         }
 
         if ($this->yformat) {
-            $this->sendCommand('set format y "'.$this->yformat.'"');
+            $this->sendCommand('set format y "' . $this->yformat . '"');
         }
 
         if ($this->xrange) {
-            $this->sendCommand('set xrange ['.$this->xrange[0].':'.$this->xrange[1].']');
+            $this->sendCommand('set xrange [' . $this->xrange[0] . ':' . $this->xrange[1] . ']');
         }
 
         if ($this->yrange) {
-            $this->sendCommand('set yrange ['.$this->yrange[0].':'.$this->yrange[1].']');
+            $this->sendCommand('set yrange [' . $this->yrange[0] . ':' . $this->yrange[1] . ']');
         }
 
         if ($this->xtics) {
@@ -496,73 +660,113 @@ class GnuPlot {
         }
 
         foreach ($this->labels as $label) {
-            $this->sendCommand('set label "'.$label[2].'" at '.$label[0].', '.$label[1]);
+            $this->sendCommand('set label "' . $label[2] . '" at ' . $label[0] . ', ' . $label[1]);
         }
     }
 
     /**
-     * Runs the plot to the given pipe
+     * Runs the plot to the given pipe.
+     *
+     * @param mixed $replot
      */
-    public function plot($replot = false)
+    public function plot($replot = false): void
     {
         if ($replot) {
             $this->sendCommand('replot');
         } else {
-            $this->sendCommand('plot '.$this->getUsings());
+            $this->sendCommand('plot ' . $this->getUsings());
         }
         $this->plotted = true;
         $this->sendData();
     }
-    
+
     /**
-     * Write the current plot to a file
+     * Gets the "using" line.
      */
-    public function write($terminal, $file)
-    {   
-        $height = $this->canvasHeight ?: $this->height;
-        $width = $this->canvasWidth ?: $this->width;
+    protected function getUsings()
+    {
+        $usings = [];
 
-        $this->sendInit();
-        $this->sendCommand("set terminal $terminal size {$width}{$this->unit}, {$height}{$this->unit}");
-        $this->sendCommand('set output "'.$file.'"');
+        foreach ($this->values as $i => $val) {
+            if (isset($this->lineModes[$i]) && self::LINEMODE_FILLEDCURVES === $this->lineModes[$i]) {
+                $using = '"-" using 1:2:3 with filledcurves ';
+            } else {
+                $using = '"-" using 1:2 with ' . ($this->lineModes[$i] ?? $this->mode);
+            }
 
-        if ($this->canvasWidth && $this->canvasHeight) {
-            $this->sendCommand("set size {$this->width}, {$this->height}");
+            if (isset($this->titles[$i])) {
+                $using .= ' title "' . $this->titles[$i] . '"';
+            }
+
+            if (isset($this->lineTypes[$i])) {
+                $using .= ' lt ' . $this->lineTypes[$i];
+            }
+
+            if (isset($this->lineColors[$i])) {
+                $using .= ' lc ' . $this->lineColors[$i];
+            }
+
+            if (isset($this->lineWidths[$i])) {
+                $using .= ' lw ' . $this->lineWidths[$i];
+            }
+
+            if (isset($this->linePoints[$i])) {
+                $using .= ' pt ' . $this->linePoints[$i];
+            }
+
+            if (isset($this->lineSmooths[$i])) {
+                $using .= ' smooth ' . $this->lineSmooths[$i];
+            }
+
+            $usings[] = $using;
         }
 
-        $this->plot();
-        
-        // Flush the output as described here: http://www.gnuplot.info/faq/faq.html#x1-840007.6
-        $this->sendCommand('set output');
-        usleep($this->sleepTime);
+        return implode(', ', $usings);
     }
 
     /**
-     * Write the current plot to a PNG file
+     * Sends all the command to the given pipe to give it the
+     * current data.
      */
-    public function writePng($file)
+    protected function sendData(): void
     {
-        $this->write(self::TERMINAL_PNG, $file);
+        foreach ($this->values as $index => $data) {
+            foreach ($data as $xy) {
+                [$x, $y] = $xy;
+                if (is_array($y)) {
+                    $this->sendCommand($x . ' ' . current($y) . ' ' . next($y));
+                } else {
+                    $this->sendCommand($x . ' ' . $y);
+                }
+            }
+            $this->sendCommand('e');
+        }
     }
-    
+
     /**
-     * Write the current plot to a PDF file
+     * Write the current plot to a PDF file.
+     *
+     * @param mixed $file
      */
-    public function writePDF($file)
+    public function writePDF($file): void
     {
         $this->write(self::TERMINAL_PDF, $file);
     }
-    
+
     /**
-     * Write the current plot to an EPS file
+     * Write the current plot to an EPS file.
+     *
+     * @param mixed $file
      */
-    public function writeEPS($file)
+    public function writeEPS($file): void
     {
         $this->write(self::TERMINAL_EPS, $file);
     }
 
     /**
-     * Write the current plot to a file
+     * Write the current plot to a file.
+     *
+     * @param mixed $format
      */
     public function get($format = self::TERMINAL_PNG)
     {
@@ -587,31 +791,31 @@ class GnuPlot {
             $data = fread($this->stdout, 128);
             $result .= $data;
             usleep($this->sleepTime);
-            $timeout-=5;
-        } while ($timeout>0 || $data);
+            $timeout -= 5;
+        } while ($timeout > 0 || $data);
 
         return $result;
     }
 
     /**
-     * Display the plot
+     * Refresh the rendering of the given pipe.
      */
-    public function display()
-    {
-        $this->sendInit();
-        $this->plot();
-    }
-
-    /**
-     * Refresh the rendering of the given pipe
-     */
-    public function refresh()
+    public function refresh(): void
     {
         if ($this->plotted) {
             $this->plot(true);
         } else {
             $this->display();
         }
+    }
+
+    /**
+     * Display the plot.
+     */
+    public function display(): void
+    {
+        $this->sendInit();
+        $this->plot();
     }
 
     public function setYFormat($yformat)
@@ -622,7 +826,9 @@ class GnuPlot {
     }
 
     /**
-     * Sets the label for X axis
+     * Sets the label for X axis.
+     *
+     * @param mixed $xlabel
      */
     public function setXLabel($xlabel)
     {
@@ -632,7 +838,9 @@ class GnuPlot {
     }
 
     /**
-     * Sets the X timeformat, example "%Y-%m-%d"
+     * Sets the X timeformat, example "%Y-%m-%d".
+     *
+     * @param mixed $timeFormat
      */
     public function setXTimeFormat($timeFormat)
     {
@@ -649,7 +857,9 @@ class GnuPlot {
     }
 
     /**
-     * Sets the label for Y axis
+     * Sets the label for Y axis.
+     *
+     * @param mixed $ylabel
      */
     public function setYLabel($ylabel)
     {
@@ -659,27 +869,34 @@ class GnuPlot {
     }
 
     /**
-     * Sets the legend position
+     * Sets the legend position.
+     *
+     * @param mixed $x
+     * @param mixed $y
      */
     public function setKey($x, $y)
     {
         $this->key = "$x $y";
 
         return $this;
-    }    
+    }
 
     /**
-     * Add a label text
+     * Add a label text.
+     *
+     * @param mixed $x
+     * @param mixed $y
+     * @param mixed $text
      */
     public function addLabel($x, $y, $text)
     {
-        $this->labels[] = array($x, $y, $text);
+        $this->labels[] = [$x, $y, $text];
 
         return $this;
     }
 
     /**
-     * Histogram mode
+     * Histogram mode.
      */
     public function enableHistogram()
     {
@@ -687,98 +904,4 @@ class GnuPlot {
 
         return $this;
     }
-
-    /**
-     * Gets the "using" line
-     */
-    protected function getUsings()
-    {
-        $usings = array();
-
-        for ($i=0; $i<count($this->values); $i++) {
-            if (isset($this->lineModes[$i]) && $this->lineModes[$i] === self::LINEMODE_FILLEDCURVES) {
-                $using = '"-" using 1:2:3 with filledcurves ';
-            } else {
-                $using = '"-" using 1:2 with ' . (isset($this->lineModes[$i]) ? $this->lineModes[$i] : $this->mode);
-            }
-
-            if (isset($this->titles[$i])) {
-                $using .= ' title "'.$this->titles[$i].'"';
-            }
-
-            if (isset($this->lineTypes[$i])) {
-                $using .= ' lt ' . $this->lineTypes[$i];
-            }
-
-            if (isset($this->lineColors[$i])) {
-                $using .= ' lc ' . $this->lineColors[$i];
-            }
-
-            if (isset($this->lineWidths[$i])) {
-                $using .= ' lw ' . $this->lineWidths[$i];
-            }
-                
-            if (isset($this->linePoints[$i])) {
-                $using .= ' pt ' . $this->linePoints[$i];
-            }
-
-            if (isset($this->lineSmooths[$i])) {
-                $using .= ' smooth ' . $this->lineSmooths[$i];
-            }
-
-            $usings[] = $using;
-        }
-        
-        return implode(', ', $usings);
-    }
-
-    /**
-     * Sends all the command to the given pipe to give it the
-     * current data
-     */
-    protected function sendData()
-    {
-        foreach ($this->values as $index => $data) {
-            foreach ($data as $xy) {
-                list($x, $y) = $xy;
-                if (is_array($y)) {
-                    $this->sendCommand($x.' '.current($y).' '.next($y));
-                } else {
-                    $this->sendCommand($x.' '.$y);
-                }
-            }
-            $this->sendCommand('e');
-        }
-    }
-
-    /**
-     * Sends a command to the gnuplot process
-     */
-    public function sendCommand($command)
-    {
-        $command .= "\n";
-        fwrite($this->stdin, $command);
-    }
-
-    /**
-     * Open the pipe
-     */
-    protected function openPipe()
-    {
-        $descriptorspec = array(
-            0 => array('pipe', 'r'),
-            1 => array('pipe', 'w'),
-            2 => array('pipe', 'r')
-        );
-
-        $this->process = proc_open('gnuplot', $descriptorspec, $pipes);
-
-        if (!is_resource($this->process)) {
-            throw new \Exception('Unable to run GnuPlot');
-        }
-
-        $this->stdin = $pipes[0];
-        $this->stdout = $pipes[1];
-    }
 }
-

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -104,6 +104,7 @@ class GnuPlot {
         $this->titles = array();
         $this->lineWidths = array();
         $this->linePoints = array();
+		$this->lineModes = array();
         $this->xrange = null;
         $this->yrange = null;
         $this->title = null;
@@ -173,6 +174,15 @@ class GnuPlot {
 
         return $this;
     }
+	
+	/**
+     * Sets the line mode of the $index th curve in the plot
+     */
+	public function setLineMode($index, $mode) {
+		$this->lineModes[$index] = $mode;
+		
+		return $this;
+	}
 
     /**
      * Sets the graph width
@@ -429,7 +439,7 @@ class GnuPlot {
         $usings = array();
 
         for ($i=0; $i<count($this->values); $i++) {
-            $using = '"-" using 1:2 with '.$this->mode;
+            $using = '"-" using 1:2 with '. (isset($this->lineModes[$i]) ? $this->lineModes[$i] : $this->mode);
             if (isset($this->titles[$i])) {
                 $using .= ' title "'.$this->titles[$i].'"';
                 
@@ -437,7 +447,7 @@ class GnuPlot {
                     $using .= ' lw ' . $this->lineWidths[$i];
                 
                 if (isset($this->linePoints[$i]))
-                    $using .= ' lp ' . $this->linePoints[$i];
+                    $using .= ' pt ' . $this->linePoints[$i];
             }
             $usings[] = $using;
         }

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -11,6 +11,7 @@ class GnuPlot {
     const TERMINAL_PDF  = 'pdf';
     const TERMINAL_EPS  = 'eps';
 
+    const SMOOTH_NONE   = null;
     const SMOOTH_SPLINE = 'cspline';
     const SMOOTH_BEZIER = 'bezier';
     
@@ -61,6 +62,9 @@ class GnuPlot {
     
     // Line Points
     protected $linePoints;
+
+    // Line Types
+    protected $lineTypes;
 
     // Smooth Mode
     protected $lineSmooths;
@@ -117,6 +121,7 @@ class GnuPlot {
         $this->lineWidths = array();
         $this->linePoints = array();
         $this->lineModes = array();
+        $this->lineTypes = array();
         $this->lineSmooths = array();
         $this->xrange = null;
         $this->yrange = null;
@@ -197,6 +202,18 @@ class GnuPlot {
         return $this;
     }
 
+    /**
+     * Sets the line type of the $index th curve in the plot
+     */
+    public function setLineType($index, $type) {
+        $this->lineTypes[$index] = $type;
+        
+        return $this;
+    }
+
+    /**
+     * Sets the line smooth of the $index th curve in the plot
+     */
     public function setLineSmooth($index, $smooth) {
         $this->lineSmooths[$index] = $smooth;
 
@@ -471,16 +488,24 @@ class GnuPlot {
             $using = '"-" using 1:2 with '. (isset($this->lineModes[$i]) ? $this->lineModes[$i] : $this->mode);
             if (isset($this->titles[$i])) {
                 $using .= ' title "'.$this->titles[$i].'"';
-                
-                if (isset($this->lineWidths[$i]))
-                    $using .= ' lw ' . $this->lineWidths[$i];
-                
-                if (isset($this->linePoints[$i]))
-                    $using .= ' pt ' . $this->linePoints[$i];
-
-                if (isset($this->lineSmooths[$i]))
-                    $using .= ' smooth ' . $this->lineSmooths[$i];
             }
+
+            if (isset($this->lineTypes[$i])) {
+                $using .= ' lt ' . $this->lineTypes[$i];
+            }
+
+            if (isset($this->lineWidths[$i])) {
+                $using .= ' lw ' . $this->lineWidths[$i];
+            }
+                
+            if (isset($this->linePoints[$i])) {
+                $using .= ' pt ' . $this->linePoints[$i];
+            }
+
+            if (isset($this->lineSmooths[$i])) {
+                $using .= ' smooth ' . $this->lineSmooths[$i];
+            }
+
             $usings[] = $using;
         }
         

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -44,6 +44,9 @@ class GnuPlot {
     // Was it already plotted?
     protected $plotted = false;
 
+    // Should draw grid for minor ticks
+    protected $minorGrid = false;
+
     // X Label
     protected $xlabel;
 
@@ -82,6 +85,12 @@ class GnuPlot {
 
     // Y tics
     protected $ytics;
+
+    // X mtics
+    protected $mxtics;
+
+    // Y mtics
+    protected $mytics;
 
     protected $yformat = null;
 
@@ -141,6 +150,9 @@ class GnuPlot {
         $this->yrange = null;
         $this->xtics = null;
         $this->ytics = null;
+        $this->mxtics = null;
+        $this->mytics = null;
+        $this->minorGrid = false;
         $this->title = null;
     }
 
@@ -180,6 +192,36 @@ class GnuPlot {
     public function setYTics($tics)
     {
         $this->ytics = $tics;
+
+        return $this;
+    }
+
+    /**
+     * Sets the X mtics for values
+     */
+    public function setMXTics($tics)
+    {
+        $this->mxtics = $tics;
+
+        return $this;
+    }
+
+    /**
+     * Sets the Y mtics for values
+     */
+    public function setMYTics($tics)
+    {
+        $this->mytics = $tics;
+
+        return $this;
+    }
+
+    /**
+     * Enables or disabled the grid for minor tics
+     */
+    public function setMinorGrid($status)
+    {
+        $this->minorGrid = $status;
 
         return $this;
     }
@@ -311,7 +353,11 @@ class GnuPlot {
      */
     protected function sendInit()
     {
-        $this->sendCommand('set grid');
+        $gridCommand = 'set grid xtics ytics';
+        if ($this->minorGrid === true) {
+            $gridCommand .= ' mxtics mytics';
+        }
+        $this->sendCommand($gridCommand);
 
         if ($this->title) {
             $this->sendCommand('set title "'.$this->title.'"');
@@ -352,6 +398,14 @@ class GnuPlot {
 
         if ($this->ytics) {
             $this->sendCommand('set ytics ' . $this->ytics);
+        }
+
+        if ($this->mxtics) {
+            $this->sendCommand('set mxtics ' . $this->mxtics);
+        }
+
+        if ($this->mytics) {
+            $this->sendCommand('set mytics ' . $this->mytics);
         }
 
         foreach ($this->labels as $label) {

--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -10,6 +10,9 @@ class GnuPlot {
     const TERMINAL_PNG  = 'png';
     const TERMINAL_PDF  = 'pdf';
     const TERMINAL_EPS  = 'eps';
+
+    const SMOOTH_SPLINE = 'cspline';
+    const SMOOTH_BEZIER = 'bezier';
     
     // Values as an array
     protected $values = array();
@@ -28,6 +31,9 @@ class GnuPlot {
 
     // Plot height
     protected $height = 800;
+
+    // Default sleep time
+    protected $sleepTime = 5000;
     
     // Size unit.
     protected $unit = self::UNIT_BLANK;
@@ -55,6 +61,9 @@ class GnuPlot {
     
     // Line Points
     protected $linePoints;
+
+    // Smooth Mode
+    protected $lineSmooths;
 
     // X range scale
     protected $xrange;
@@ -107,7 +116,8 @@ class GnuPlot {
         $this->titles = array();
         $this->lineWidths = array();
         $this->linePoints = array();
-		$this->lineModes = array();
+        $this->lineModes = array();
+        $this->lineSmooths = array();
         $this->xrange = null;
         $this->yrange = null;
         $this->title = null;
@@ -177,15 +187,21 @@ class GnuPlot {
 
         return $this;
     }
-	
-	/**
+    
+    /**
      * Sets the line mode of the $index th curve in the plot
      */
-	public function setLineMode($index, $mode) {
-		$this->lineModes[$index] = $mode;
-		
-		return $this;
-	}
+    public function setLineMode($index, $mode) {
+        $this->lineModes[$index] = $mode;
+        
+        return $this;
+    }
+
+    public function setLineSmooth($index, $smooth) {
+        $this->lineSmooths[$index] = $smooth;
+
+        return $this;
+    }
 
     /**
      * Sets the graph width
@@ -203,6 +219,16 @@ class GnuPlot {
     public function setHeight($height)
     {
         $this->height = $height;
+
+        return $this;
+    }
+
+    /**
+     * Sets the sleep time
+     */
+    public function setSleepTime($sleepTime)
+    {
+        $this->sleepTime = $sleepTime;
 
         return $this;
     }
@@ -298,7 +324,7 @@ class GnuPlot {
         
         // Flush the output as described here: http://www.gnuplot.info/faq/faq.html#x1-840007.6
         $this->sendCommand('set output');
-        usleep(5000);
+        usleep($this->sleepTime);
     }
 
     /**
@@ -342,7 +368,7 @@ class GnuPlot {
             stream_set_blocking($this->stdout, false);
             $data = fread($this->stdout, 128);
             $result .= $data;
-            usleep(5000);
+            usleep($this->sleepTime);
             $timeout-=5;
         } while ($timeout>0 || $data);
 
@@ -451,6 +477,9 @@ class GnuPlot {
                 
                 if (isset($this->linePoints[$i]))
                     $using .= ' pt ' . $this->linePoints[$i];
+
+                if (isset($this->lineSmooths[$i]))
+                    $using .= ' smooth ' . $this->lineSmooths[$i];
             }
             $usings[] = $using;
         }

--- a/README.md
+++ b/README.md
@@ -118,6 +118,9 @@ API
 * `setMinorGrid($status)`, enabled/disables the grid for microtics
 * `setWidth($width)`, sets the width of the graph
 * `setHeight($height)`, sets the width of the graph
+* `setCanvasWidth($width)`, sets the width of the canvas (if not set, the width value is used)
+* `setCanvasHeight($height)`, sets the width of the canvas (if not set, the height value is used)
+* `setOrigin($x, $y)`, sets the origin of the graph
 * `setSleepTime($sleepTime)`, sets the sleep time after saving a file
 * `addLabel($x, $y, $text)`, add some label at a point
 * `flush()`, completely flushes the internal state and resets the object to its initial state

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ $plot
     ->push(0, [4, 8], 2)
     ->push(1, [5, 9], 2)
     ->push(2, [6,10], 2)
+    ;
 ```
 
 You can then save it to a file, have a look to `write.php` for example:

--- a/README.md
+++ b/README.md
@@ -111,7 +111,9 @@ API
 * `setYRange($min, $max)`, set the Y min & max
 * `setWidth($width)`, sets the width of the graph
 * `setHeight($height)`, sets the width of the graph
+* `setSleepTime($sleepTime)`, sets the sleep time after saving a file
 * `addLabel($x, $y, $text)`, add some label at a point
+* `flush()`, completely flushes the internal state and resets the object to its initial state
 
 License
 =======

--- a/README.md
+++ b/README.md
@@ -114,7 +114,8 @@ API
 * `setLineWidth($index, $width)`, sets the width of the $index-nt curve
 * `setLineMode($index, $mode)`, sets the line mode of the $index-nt curve (set to `GnuPlot::LINEMODE_FILLEDCURVES` to fill an area between two lines)
 * `setLinePoint($index, $point)`, sets the line point of the $index-nt curve
-* `setLineType($index, $type)`, sets the line type of the $index-nt curve (for example to change the line's color)
+* `setLineType($index, $type)`, sets the line type of the $index-nt curve
+* `setLineColor($index, $color)`, sets the line color of the $index-nt curve
 * `setLineSmooth($index, $smooth)`, sets the smooth type of the $index-nt curve. Available smooths are `SMOOTH_NONE`, `SMOOTH_BEZIER`, `SMOOTH_CSPLINE`, defined as constants on the `GnuPlot` class.
 * `setGraphTitle($title)`, sets the main title for the graph
 * `setXTimeFormat($format)`, sets the X axis as a time axis and specify data format
@@ -129,6 +130,7 @@ API
 * `setMXTics($tics)`, set the micro X tics
 * `setMYTics($tics)`, set the micro Y tics
 * `setMinorGrid($status)`, enabled/disables the grid for microtics
+* `setGridPlacement($layer)`, sets the placement of the grid, can be GnuPlot::GRID_DEFAULT, GnuPlot::GRID_FRONT or GnuPlot::GRID_BACK
 * `setWidth($width)`, sets the width of the graph
 * `setHeight($height)`, sets the height of the graph
 * `setCanvasWidth($width)`, sets the width of the canvas (if not set, the width value is used)

--- a/README.md
+++ b/README.md
@@ -94,8 +94,13 @@ API
 * `refresh()`, same as `display()`, but will replot the graph after
   the first call
 * `get()`, gets the PNG data for your image
-* `writePng($filename)`, write the data to the output file
+* `writePng($filename)`, writes the data to the output PNG file
+* `writePDF($filename)`, writes the data to the output PDF file
+* `writeEPS($filename)`, writes the data to the output EPS file
 * `setTitle($index, $title)`, sets the title of the $index-nt curve
+* `setLineWidth($index, $title)`, sets the width of the $index-nt curve
+* `setLineMode($index, $title)`, sets the line mode of the $index-nt curve
+* `setLinePoint($index, $title)`, sets the line point of the $index-nt curve
 * `setGraphTitle($title)`, sets the main title for the graph
 * `setXTimeFormat($format)`, sets the X axis as a time axis and specify data format
 * `setXTimeFormatString($format)`, specify the X axis time presentation format

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ API
 * `setMXTics($tics)`, set the micro X tics
 * `setMYTics($tics)`, set the micro Y tics
 * `setMinorGrid($status)`, enabled/disables the grid for microtics
-* `setGridPlacement($layer)`, sets the placement of the grid, can be GnuPlot::GRID_DEFAULT, GnuPlot::GRID_FRONT or GnuPlot::GRID_BACK
+* `setGridPlacement($layer)`, sets the placement of the grid, can be `GnuPlot::GRID_DEFAULT`, `GnuPlot::GRID_FRONT` or `GnuPlot::GRID_BACK`
 * `setWidth($width)`, sets the width of the graph
 * `setHeight($height)`, sets the height of the graph
 * `setCanvasWidth($width)`, sets the width of the canvas (if not set, the width value is used)

--- a/README.md
+++ b/README.md
@@ -38,14 +38,26 @@ $plot
     ->push(2, 6)
     ;
 
-// Adding three points on the other curve
+// Adding three points on the other curve and drawing it as a line of connected points, colored in red and smoothed
 // (with index 1)
 $plot
     ->setTitle(1, 'The first curve')
+    ->setLineType(1, 'rgb #ff0000')
+    ->setLineMode(1, 'lp')
+    ->setLineSmooth(1, GnuPlot::SMOOTH_CSPLINE)
     ->push(0, 8, 1)
     ->push(1, 9, 1)
-    ->push(2, 10, 2)
+    ->push(2, 10, 1)
     ;
+
+// Drawing the area between the two curves in blue
+$plot
+    ->setLineMode(2, GnuPlot::LINEMODE_FILLEDCURVES)
+    ->setLineType(2, 'rgb #0000ff')
+    ->setTitle(2, 'Area')
+    ->push(0, [4, 8], 2)
+    ->push(1, [5, 9], 2)
+    ->push(2, [6,10], 2)
 ```
 
 You can then save it to a file, have a look to `write.php` for example:
@@ -88,7 +100,7 @@ $plot->refresh();
 API
 ===
 
-* `push($x, $y, $index=0)`, add a point to the $index-nth curve
+* `push($x, $y, $index=0)`, add a point to the $index-nth curve ($y can be an array if the linemode is `GnuPlot::LINEMODE_FILLEDCURVES`)
 * `display()`, renders the graph on the screen (asuming you are using
   it as a CLI with an X Server
 * `refresh()`, same as `display()`, but will replot the graph after
@@ -99,7 +111,7 @@ API
 * `writeEPS($filename)`, writes the data to the output EPS file
 * `setTitle($index, $title)`, sets the title of the $index-nt curve
 * `setLineWidth($index, $width)`, sets the width of the $index-nt curve
-* `setLineMode($index, $mode)`, sets the line mode of the $index-nt curve
+* `setLineMode($index, $mode)`, sets the line mode of the $index-nt curve (set to `GnuPlot::LINEMODE_FILLEDCURVES` to fill an area between two lines)
 * `setLinePoint($index, $point)`, sets the line point of the $index-nt curve
 * `setLineType($index, $type)`, sets the line type of the $index-nt curve (for example to change the line's color)
 * `setLineSmooth($index, $smooth)`, sets the smooth type of the $index-nt curve. Available smooths are `SMOOTH_NONE`, `SMOOTH_BEZIER`, `SMOOTH_CSPLINE`, defined as constants on the `GnuPlot` class.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ API
 * `setLineSmooth($index, $smooth)`, sets the smooth type of the $index-nt curve. Available smooths are `SMOOTH_NONE`, `SMOOTH_BEZIER`, `SMOOTH_CSPLINE`, defined as constants on the `GnuPlot` class.
 * `setGraphTitle($title)`, sets the main title for the graph
 * `setXTimeFormat($format)`, sets the X axis as a time axis and specify data format
-* `setXTimeFormatString($format)`, specify the X axis time presentation format
+* `setTimeFormatString($format)`, specify the X axis time presentation format
 * `setXLabel($text)`, sets the label for the X axis
 * `setYLabel($text)`, sets the label for the Y axis
 * `setYFormat($format)`, sets Y axis formatting
@@ -130,9 +130,9 @@ API
 * `setMYTics($tics)`, set the micro Y tics
 * `setMinorGrid($status)`, enabled/disables the grid for microtics
 * `setWidth($width)`, sets the width of the graph
-* `setHeight($height)`, sets the width of the graph
+* `setHeight($height)`, sets the height of the graph
 * `setCanvasWidth($width)`, sets the width of the canvas (if not set, the width value is used)
-* `setCanvasHeight($height)`, sets the width of the canvas (if not set, the height value is used)
+* `setCanvasHeight($height)`, sets the height of the canvas (if not set, the height value is used)
 * `setOrigin($x, $y)`, sets the origin of the graph
 * `setSleepTime($sleepTime)`, sets the sleep time after saving a file
 * `addLabel($x, $y, $text)`, add some label at a point

--- a/README.md
+++ b/README.md
@@ -98,9 +98,11 @@ API
 * `writePDF($filename)`, writes the data to the output PDF file
 * `writeEPS($filename)`, writes the data to the output EPS file
 * `setTitle($index, $title)`, sets the title of the $index-nt curve
-* `setLineWidth($index, $title)`, sets the width of the $index-nt curve
-* `setLineMode($index, $title)`, sets the line mode of the $index-nt curve
-* `setLinePoint($index, $title)`, sets the line point of the $index-nt curve
+* `setLineWidth($index, $width)`, sets the width of the $index-nt curve
+* `setLineMode($index, $mode)`, sets the line mode of the $index-nt curve
+* `setLinePoint($index, $point)`, sets the line point of the $index-nt curve
+* `setLineType($index, $type)`, sets the line type of the $index-nt curve (for example to change the line's color)
+* `setLineSmooth($index, $smooth)`, sets the smooth type of the $index-nt curve. Available smooths are `SMOOTH_NONE`, `SMOOTH_BEZIER`, `SMOOTH_CSPLINE`, defined as constants on the `GnuPlot` class.
 * `setGraphTitle($title)`, sets the main title for the graph
 * `setXTimeFormat($format)`, sets the X axis as a time axis and specify data format
 * `setXTimeFormatString($format)`, specify the X axis time presentation format
@@ -109,6 +111,11 @@ API
 * `setYFormat($format)`, sets Y axis formatting
 * `setXRange($min, $max)`, set the X min & max
 * `setYRange($min, $max)`, set the Y min & max
+* `setXTics($tics)`, set the X tics
+* `setYTics($tics)`, set the Y tics
+* `setMXTics($tics)`, set the micro X tics
+* `setMYTics($tics)`, set the micro Y tics
+* `setMinorGrid($status)`, enabled/disables the grid for microtics
 * `setWidth($width)`, sets the width of the graph
 * `setHeight($height)`, sets the width of the graph
 * `setSleepTime($sleepTime)`, sets the sleep time after saving a file

--- a/demo/date.php
+++ b/demo/date.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
-include ('../GnuPlot.php');
+include('../GnuPlot.php');
 
 use Gregwar\GnuPlot\GnuPlot;
 
-$plot = new GnuPlot;
+$plot = new GnuPlot();
 
 $plot
     ->setXLabel('Date')
@@ -24,4 +24,4 @@ $plot
     ->setWidth(400)
     ->setHeight(300)
     ->writePng('date.png')
-    ;
+;

--- a/demo/demo.php
+++ b/demo/demo.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
-include ('../GnuPlot.php');
+include('../GnuPlot.php');
 
 use Gregwar\GnuPlot\GnuPlot;
 
-$plot = new GnuPlot;
+$plot = new GnuPlot();
 
 $plot
     ->setXLabel('X')
@@ -17,6 +17,7 @@ $plot
     ->push(3, 2.6)
     ->push(4, 5.3)
     ->setTitle(0, 'The curve')
-    ->display();
+    ->display()
+;
 
 sleep(1000);

--- a/demo/eps.php
+++ b/demo/eps.php
@@ -1,38 +1,38 @@
-<?php
+<?php declare(strict_types=1);
 
-include ('../GnuPlot.php');
+include('../GnuPlot.php');
 
 use Gregwar\GnuPlot\GnuPlot;
 
-$plot = new GnuPlot;
+$plot = new GnuPlot();
 
 $plot
-	// Setting graph main title
-	->setGraphTitle('Demo graph')
-	// Setting X & Y labels
-	->setXLabel('Something')
-	->setYLabel('Another something')
-	// Set the unit to inches
-	->setUnit(GnuPlot::UNIT_INCH)
-	// Setting graph dimensions to those of an A4 sheet
-	->setWidth(11.02)
-	->setHeight(8.27)
-	// Demo curve (index=0)
-	->setTitle(0, 'Demo')
-	->push(0, 1)
-	->push(1, 10)
-	->push(2, 3)
-	->push(3, 2.6)
-	->push(4, 5.3)
-	// Other curve, (index=1)
-	->setTitle(1, 'Other curve')
-	->push(0, 3.9, 1)
-	->push(1, 2.3, 1)
-	->push(2, 4.3, 1)
-	->push(3, 3.1, 1)
-	->push(4, 5.2, 1)
-	// Pointing out a value
-	->addLabel(2, 4.3, 'An important point')
-	// Writing to out.png
-	->writeEPS('out.eps');
-
+    // Setting graph main title
+    ->setGraphTitle('Demo graph')
+    // Setting X & Y labels
+    ->setXLabel('Something')
+    ->setYLabel('Another something')
+    // Set the unit to inches
+    ->setUnit(GnuPlot::UNIT_INCH)
+    // Setting graph dimensions to those of an A4 sheet
+    ->setWidth(11.02)
+    ->setHeight(8.27)
+    // Demo curve (index=0)
+    ->setTitle(0, 'Demo')
+    ->push(0, 1)
+    ->push(1, 10)
+    ->push(2, 3)
+    ->push(3, 2.6)
+    ->push(4, 5.3)
+    // Other curve, (index=1)
+    ->setTitle(1, 'Other curve')
+    ->push(0, 3.9, 1)
+    ->push(1, 2.3, 1)
+    ->push(2, 4.3, 1)
+    ->push(3, 3.1, 1)
+    ->push(4, 5.2, 1)
+    // Pointing out a value
+    ->addLabel(2, 4.3, 'An important point')
+    // Writing to out.png
+    ->writeEPS('out.eps')
+;

--- a/demo/out.php
+++ b/demo/out.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
-include ('../GnuPlot.php');
+include('../GnuPlot.php');
 
 use Gregwar\GnuPlot\GnuPlot;
 
-$plot = new GnuPlot;
+$plot = new GnuPlot();
 
 header('Content-type: image/png');
 
@@ -20,5 +20,5 @@ echo $plot
     ->push(3, 2.6)
     ->push(4, 5.3)
     ->setTitle(0, 'Demo')
-    ->get();
-
+    ->get()
+;

--- a/demo/pdf.php
+++ b/demo/pdf.php
@@ -1,38 +1,38 @@
-<?php
+<?php declare(strict_types=1);
 
-include ('../GnuPlot.php');
+include('../GnuPlot.php');
 
 use Gregwar\GnuPlot\GnuPlot;
 
-$plot = new GnuPlot;
+$plot = new GnuPlot();
 
 $plot
-	// Setting graph main title
-	->setGraphTitle('Demo graph')
-	// Setting X & Y labels
-	->setXLabel('Something')
-	->setYLabel('Another something')
-	// Set the unit to inches
-	->setUnit(GnuPlot::UNIT_INCH)
-	// Setting graph dimensions to those of an A4 sheet
-	->setWidth(11.02)
-	->setHeight(8.27)
-	// Demo curve (index=0)
-	->setTitle(0, 'Demo')
-	->push(0, 1)
-	->push(1, 10)
-	->push(2, 3)
-	->push(3, 2.6)
-	->push(4, 5.3)
-	// Other curve, (index=1)
-	->setTitle(1, 'Other curve')
-	->push(0, 3.9, 1)
-	->push(1, 2.3, 1)
-	->push(2, 4.3, 1)
-	->push(3, 3.1, 1)
-	->push(4, 5.2, 1)
-	// Pointing out a value
-	->addLabel(2, 4.3, 'An important point')
-	// Writing to out.png
-	->writePDF('out.pdf');
-
+    // Setting graph main title
+    ->setGraphTitle('Demo graph')
+    // Setting X & Y labels
+    ->setXLabel('Something')
+    ->setYLabel('Another something')
+    // Set the unit to inches
+    ->setUnit(GnuPlot::UNIT_INCH)
+    // Setting graph dimensions to those of an A4 sheet
+    ->setWidth(11.02)
+    ->setHeight(8.27)
+    // Demo curve (index=0)
+    ->setTitle(0, 'Demo')
+    ->push(0, 1)
+    ->push(1, 10)
+    ->push(2, 3)
+    ->push(3, 2.6)
+    ->push(4, 5.3)
+    // Other curve, (index=1)
+    ->setTitle(1, 'Other curve')
+    ->push(0, 3.9, 1)
+    ->push(1, 2.3, 1)
+    ->push(2, 4.3, 1)
+    ->push(3, 3.1, 1)
+    ->push(4, 5.2, 1)
+    // Pointing out a value
+    ->addLabel(2, 4.3, 'An important point')
+    // Writing to out.png
+    ->writePDF('out.pdf')
+;

--- a/demo/realTime.php
+++ b/demo/realTime.php
@@ -1,11 +1,11 @@
-<?php
+<?php declare(strict_types=1);
 
-include ('../GnuPlot.php');
+include('../GnuPlot.php');
 
 use Gregwar\GnuPlot\GnuPlot;
 
 $alpha = 0;
-$plot = new GnuPlot;
+$plot  = new GnuPlot();
 
 while (true) {
     usleep(50000);
@@ -13,12 +13,12 @@ while (true) {
     $plot->setGraphTitle('The magic sinuses');
     $plot->setTitle(0, 'The moving sinus');
     $plot->setTitle(1, 'The moving cosinus');
-    for ($x=0; $x<10; $x+=0.01) {
-        $plot->push($x, sin($alpha+$x));
-        $plot->push($x, cos($alpha*1.5+$x), 1);
+    for ($x = 0; $x < 10; $x += 0.01) {
+        $plot->push($x, sin($alpha + $x));
+        $plot->push($x, cos($alpha * 1.5 + $x), 1);
     }
+    $plot->plot();
     $alpha += 0.1;
-    $plot->refresh();
 }
 
 sleep(1000);

--- a/demo/write.php
+++ b/demo/write.php
@@ -1,10 +1,10 @@
-<?php
+<?php declare(strict_types=1);
 
-include ('../GnuPlot.php');
+include('../GnuPlot.php');
 
 use Gregwar\GnuPlot\GnuPlot;
 
-$plot = new GnuPlot;
+$plot = new GnuPlot();
 
 $plot
     // Setting graph main title
@@ -32,5 +32,5 @@ $plot
     // Pointing out a value
     ->addLabel(2, 4.3, 'An important point')
     // Writing to out.png
-    ->writePng('out.png');
-
+    ->writePng('out.png')
+;


### PR DESCRIPTION
I've added support for individual line widths, points and curve smoothing. The new methods follow the original style, so they are chainable and the parameter order is the same as the other line-specific methods.

I've also added the ability to set the sleep time and to completely flush the graph object, in order to overcome some issues I've been having when saving PDF files: the output needed to be properly flushed and since I couldn't find an elegant way to determine whether the gnuplot process had completed said operation, I opted for a more simple, less elegant sleep. This should be set to higher values if the machine is not powerful enough and/or if the graph is particularly complex (many curves, etc).
There is also the nuclear option to flush() the object before serving the output file: this should ensure that the flushing is complete, but also loses all the state within the object (all curves, all options, etc).

Coming up: multigraph support :)
