### PR TITLE
Fix displaying chart in console when running inside docker container

### DIFF
--- a/GnuPlot.php
+++ b/GnuPlot.php
@@ -181,6 +181,7 @@ class GnuPlot {
     protected function sendInit()
     {
         $this->sendCommand('set grid');
+        $this->sendCommand('set terminal dumb');
 
         if ($this->title) {
             $this->sendCommand('set title "'.$this->title.'"');


### PR DESCRIPTION
This change fixes rendering charts in CLI when running inside docker containers. Previously, I got this error:

```
gnuplot> plot sin(x)
QXcbConnection: Could not connect to display
```

No breaking changes noticed.